### PR TITLE
ZOSVPC - 2871 Implementation of giving an option of creating z/os vsi with a specified profile size for quick start variation.

### DIFF
--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -9,7 +9,10 @@ module "landing_zone" {
   prefix               = var.prefix
   region               = var.region
   ssh_key              = var.ssh_key
-  override_json_string = var.override_json_string
+  override_json_string = local.out
+}
+locals {
+  out = replace(var.override_json_string,"mz2o-2x16",var.machine_type)
 }
 
 ########################################################################################################################

--- a/solutions/quickstart/variables.tf
+++ b/solutions/quickstart/variables.tf
@@ -36,6 +36,15 @@ variable "ssh_key" {
   }
 }
 
+variable "machine_type" {
+  type = string 
+  description = "input machine type: valid values are: bz2-4x16, bz2-8x32, bz2-16x64, cz2-8x16, cz2-16x32, mz2-2x16, mz2-4x32, mz2-8x64, mz2-16x128"
+  validation {
+    condition  = contains(["bz2-4x16", "bz2-8x32", "bz2-16x64", "cz2-8x16", "cz2-16x32", "mz2-2x16", "mz2-4x32", "mz2-8x64", "mz2-16x128"], var.machine_type)
+    error_message = "Valid values for machine_type are: bz2-4x16, bz2-8x32, bz2-16x64, cz2-8x16, cz2-16x32, mz2-2x16, mz2-4x32, mz2-8x64, mz2-16x128"
+  }
+}
+
 variable "resource_tags" {
   type        = list(string)
   description = "Optional list of tags to be added to created resources"

--- a/solutions/quickstart/variables.tf
+++ b/solutions/quickstart/variables.tf
@@ -40,7 +40,7 @@ variable "machine_type" {
   type = string 
   description = "input machine type: valid values are: bz2-4x16, bz2-8x32, bz2-16x64, cz2-8x16, cz2-16x32, mz2-2x16, mz2-4x32, mz2-8x64, mz2-16x128"
   validation {
-    condition  = contains(["bz2-4x16", "bz2-8x32", "bz2-16x64", "cz2-8x16", "cz2-16x32", "mz2-2x16", "mz2-4x32", "mz2-8x64", "mz2-16x128"], var.machine_type)
+    condition  = contains(["mz2o-2x16", "bz2-4x16", "bz2-8x32", "bz2-16x64", "cz2-8x16", "cz2-16x32", "mz2-2x16", "mz2-4x32", "mz2-8x64", "mz2-16x128"], var.machine_type)
     error_message = "Valid values for machine_type are: bz2-4x16, bz2-8x32, bz2-16x64, cz2-8x16, cz2-16x32, mz2-2x16, mz2-4x32, mz2-8x64, mz2-16x128"
   }
 }


### PR DESCRIPTION
1. Give the option of creating a z/OS VSI with a specified profile size
validate the input profile size to ensure that z/OS VSI will IPL successfully - that is, >= 2 vCPUS and >= 16GB RAM. For example, the following existing IBM Z profiles will NOT work:
bz2-1x4
bz2-2x8
cz2-2x4
cz2-4x8
2. Support the profile size option for quick start variation.